### PR TITLE
test: add Playwright E2E suite and route-config unit spec

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,51 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  playwright:
+    name: Playwright (chromium + mobile)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci --no-audit --no-fund
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        env:
+          CI: 'true'
+        run: npm run e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Upload traces & videos
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: test-results/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ SUPABASE_SETUP.md
 *.tmp
 *.bak
 *.orig
+
+# Playwright
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,31 @@
+# E2E Tests
+
+End-to-end tests powered by [Playwright](https://playwright.dev).
+
+## Run locally
+
+```bash
+# one-time browser install
+npm run e2e:install
+
+# headless run (auto-starts ng serve on :4200)
+npm run e2e
+
+# interactive UI mode
+npm run e2e:ui
+```
+
+Override the target with `E2E_BASE_URL=https://staging.example.com npm run e2e`.
+
+## Layout
+
+- `fixtures.ts` — shared Playwright fixtures (e.g. `unauthenticatedPage` clears Supabase session).
+- `pages/` — Page Object Models. One file per screen, all selectors centralised.
+- `*.spec.ts` — test suites grouped by user-facing feature.
+
+## Conventions
+
+- Use Page Objects for any non-trivial screen — never assert on raw selectors inside specs.
+- Prefer role/label-based locators (`getByRole`, `getByLabel`) over CSS where possible.
+- Tests must be **independent** — no shared mutable state between specs.
+- Avoid hitting real Supabase from CI; the current suite covers guard/redirect and form-validation flows that work without a backend round-trip.

--- a/e2e/auth-flow.spec.ts
+++ b/e2e/auth-flow.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from './fixtures';
+import { LoginPage } from './pages/login.page';
+
+test.describe('Authentication flow', () => {
+  test('redirects unauthenticated visitors from "/" to /login', async ({ unauthenticatedPage: page }) => {
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.locator('input[formControlName="email"]')).toBeVisible();
+  });
+
+  test('login form submit stays disabled until both fields are valid', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+
+    await expect(login.submitButton).toBeDisabled();
+
+    await login.emailInput.fill('not-an-email');
+    await login.passwordInput.fill('short');
+    await login.emailInput.blur();
+    await login.passwordInput.blur();
+
+    await expect(login.submitButton).toBeDisabled();
+
+    await login.fill('valid@example.com', 'longenoughpassword');
+    await expect(login.submitButton).toBeEnabled();
+  });
+
+  test('clicking the register link navigates to /register', async ({ page }) => {
+    const login = new LoginPage(page);
+    await login.goto();
+
+    await login.registerLink.first().click();
+    await expect(page).toHaveURL(/\/register$/);
+    await expect(page.locator('input[formControlName="username"]')).toBeVisible();
+    await expect(page.locator('input[formControlName="email"]')).toBeVisible();
+    await expect(page.locator('input[formControlName="password"]')).toBeVisible();
+  });
+
+  test('register form rejects invalid email and weak password', async ({ page }) => {
+    await page.goto('/register');
+    const submit = page.locator('button[type="submit"]');
+
+    await expect(submit).toBeDisabled();
+
+    await page.locator('input[formControlName="username"]').fill('user');
+    await page.locator('input[formControlName="email"]').fill('bad');
+    await page.locator('input[formControlName="password"]').fill('123');
+
+    await expect(submit).toBeDisabled();
+  });
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,28 @@
+import { test as base, expect, Page } from '@playwright/test';
+
+export { expect };
+
+/**
+ * Project-specific fixtures.
+ *
+ * `unauthenticatedPage` guarantees no Supabase session is present in
+ * localStorage before the page navigates — keeps guard-redirect tests
+ * deterministic across runs and across machines.
+ */
+export const test = base.extend<{ unauthenticatedPage: Page }>({
+  unauthenticatedPage: async ({ page, baseURL }, use) => {
+    await page.addInitScript(() => {
+      try {
+        for (const key of Object.keys(window.localStorage)) {
+          if (key.startsWith('sb-') || key.includes('supabase')) {
+            window.localStorage.removeItem(key);
+          }
+        }
+      } catch {
+        /* storage unavailable in some contexts — ignore */
+      }
+    });
+    await page.goto(baseURL ?? '/');
+    await use(page);
+  },
+});

--- a/e2e/pages/login.page.ts
+++ b/e2e/pages/login.page.ts
@@ -1,0 +1,35 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * Page Object for the login screen.
+ * Centralises selectors so a template change touches one file, not every test.
+ */
+export class LoginPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+  readonly registerLink: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.locator('input[formControlName="email"]');
+    this.passwordInput = page.locator('input[formControlName="password"]');
+    this.submitButton = page.locator('button[type="submit"]');
+    this.registerLink = page.getByRole('link', { name: /register|sign\s*up/i });
+  }
+
+  async goto() {
+    await this.page.goto('/login');
+    await expect(this.emailInput).toBeVisible();
+  }
+
+  async fill(email: string, password: string) {
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+  }
+
+  async submit() {
+    await this.submitButton.click();
+  }
+}

--- a/e2e/routing.spec.ts
+++ b/e2e/routing.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from './fixtures';
+
+test.describe('Routing & guards', () => {
+  test('unknown route renders the 404 component', async ({ page }) => {
+    await page.goto('/this-route-does-not-exist');
+    // Page-not-found component should render *something* visible from a 404 view.
+    // We assert no router-outlet error and that body text is non-empty.
+    await expect(page.locator('app-page-not-found, [data-testid="page-not-found"], main, body')).toBeVisible();
+    const bodyText = (await page.locator('body').innerText()).toLowerCase();
+    expect(bodyText.length).toBeGreaterThan(0);
+  });
+
+  test('protected /profile redirects unauthenticated users to /login', async ({ unauthenticatedPage: page }) => {
+    await page.goto('/profile');
+    await expect(page).toHaveURL(/\/login$/);
+  });
+
+  test('protected /car-view/:id redirects unauthenticated users to /login', async ({ unauthenticatedPage: page }) => {
+    await page.goto('/car-view/abc-123');
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});
+
+test.describe('Accessibility smoke', () => {
+  test('login page exposes labelled email + password inputs', async ({ page }) => {
+    await page.goto('/login');
+    const email = page.locator('input[formControlName="email"]');
+    const password = page.locator('input[formControlName="password"]');
+    await expect(email).toHaveAttribute('type', 'email');
+    await expect(password).toHaveAttribute('type', 'password');
+    await expect(email).toHaveAttribute('autocomplete', /email|username/);
+  });
+
+  test('every page has a non-empty <title>', async ({ page }) => {
+    for (const path of ['/login', '/register']) {
+      await page.goto(path);
+      await expect(page).toHaveTitle(/.+/);
+    }
+  });
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc/e2e",
+    "module": "commonjs",
+    "target": "es2022",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts", "../playwright.config.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadless --code-coverage",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install --with-deps chromium",
     "serve:ssr:carfinder": "node dist/carfinder/server/server.mjs"
   },
   "private": true,
@@ -38,6 +42,7 @@
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^18.18.0",
+    "@playwright/test": "^1.48.0",
     "concurrently": "^9.2.1",
     "jasmine-core": "~5.5.0",
     "karma": "~6.4.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = Number(process.env['E2E_PORT'] ?? 4200);
+const BASE_URL = process.env['E2E_BASE_URL'] ?? `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env['CI'],
+  retries: process.env['CI'] ? 2 : 0,
+  workers: process.env['CI'] ? 2 : undefined,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+  ],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile', use: { ...devices['Pixel 7'] } },
+  ],
+  webServer: {
+    command: `npx ng serve --port=${PORT} --host=127.0.0.1 --configuration=development`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env['CI'],
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,44 @@
+import { routes } from './app.routes';
+import { authGuard } from './guard/auth.guard';
+import { guestGuard } from './guard/guest.guard';
+
+/**
+ * Pure structural assertions — no Angular TestBed needed.
+ * Catches accidental route regressions (missing guard, lost lazy-loaded chunk,
+ * removed wildcard fallback) without booting the application.
+ */
+describe('app.routes', () => {
+  const byPath = (path: string) => routes.find(r => r.path === path);
+
+  it('every non-wildcard route is lazy-loaded via loadComponent', () => {
+    for (const route of routes) {
+      if (route.path === '**') continue;
+      expect(typeof route.loadComponent).toBe('function');
+    }
+  });
+
+  it('protected routes require authGuard', () => {
+    for (const path of ['', 'car-view/:id', 'profile']) {
+      const route = byPath(path);
+      expect(route).withContext(`route "${path}" missing`).toBeDefined();
+      expect(route!.canActivate).toContain(authGuard);
+    }
+  });
+
+  it('public auth routes use guestGuard so signed-in users cannot revisit them', () => {
+    for (const path of ['login', 'register']) {
+      const route = byPath(path);
+      expect(route).withContext(`route "${path}" missing`).toBeDefined();
+      expect(route!.canActivate).toContain(guestGuard);
+    }
+  });
+
+  it('declares a wildcard 404 fallback as the last entry', () => {
+    expect(routes[routes.length - 1].path).toBe('**');
+  });
+
+  it('every route exposes a unique path', () => {
+    const paths = routes.map(r => r.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});


### PR DESCRIPTION
- playwright.config.ts: chromium + mobile projects, auto-spawned ng serve, traces/videos on failure
- e2e/: page-object pattern (LoginPage), shared fixtures (unauthenticatedPage), auth-flow + routing + a11y smoke specs
- e2e.yml workflow: cached browser install, artifact upload of HTML report and failure traces
- app.routes.spec.ts: structural invariants (lazy loading, guards on protected routes, wildcard fallback)
- npm scripts: test:ci, e2e, e2e:ui, e2e:install