### PR TITLE
fix: add node types to tsconfig.spec.json to resolve process.env TS25…

### DIFF
--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -5,7 +5,8 @@
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
     "types": [
-      "jasmine"
+      "jasmine",
+      "node"
     ]
   },
   "include": [


### PR DESCRIPTION
…91 error

runtime-config.ts uses process.env in its SSR branch. tsconfig.spec.json sets an explicit types list (['jasmine']) which suppresses @types/node, making the spec compilation unable to resolve 'process'. Adding 'node' to the list fixes TS2591 without requiring any new packages.