### PR TITLE
fix: guard process access in getRuntimeConfig for browser/test enviro…

### DIFF
--- a/src/app/common/runtime-config.ts
+++ b/src/app/common/runtime-config.ts
@@ -9,9 +9,11 @@ export function getRuntimeConfig(): { supabaseUrl: string; supabaseKey: string }
   if (typeof window !== 'undefined' && window.__env) {
     return window.__env;
   }
-  // Server (SSR) context — read directly from process environment
+  // Server (SSR/Node) context — read directly from process environment.
+  // Guard required: `process` does not exist in browser or Karma test environments.
+  const env = typeof process !== 'undefined' ? process.env : {};
   return {
-    supabaseUrl: process.env['SUPABASE_URL'] ?? '',
-    supabaseKey: process.env['SUPABASE_KEY'] ?? '',
+    supabaseUrl: env['SUPABASE_URL'] ?? '',
+    supabaseKey: env['SUPABASE_KEY'] ?? '',
   };
 }


### PR DESCRIPTION
…nments

In the Karma test environment window is defined but window.__env is never injected (that is done by the SSR server at request time), so getRuntimeConfig fell through to process.env — which does not exist in browsers — causing a ReferenceError at runtime in all tests that instantiated SupabaseService.

Added a typeof process !== 'undefined' guard so the function safely returns empty strings in any environment where process is absent.